### PR TITLE
fix encoding

### DIFF
--- a/Public/Send-TeamsMessage.ps1
+++ b/Public/Send-TeamsMessage.ps1
@@ -27,7 +27,7 @@ function Send-TeamsMessage {
         -Sections $Sections `
         -MessageSummary $MessageSummary
     try {
-        $Execute = Invoke-RestMethod -Uri $uri -Method Post -Body $Body -ContentType 'application/json'
+        $Execute = Invoke-RestMethod -Uri $uri -Method Post -Body $Body -ContentType 'application/json; charset=UTF-8'
     } catch {
         $ErrorMessage = $_.Exception.Message -replace "`n", " " -replace "`r", " "
         if ($ShowErrors) {

--- a/Public/Send-TeamsMessageBody.ps1
+++ b/Public/Send-TeamsMessageBody.ps1
@@ -4,7 +4,7 @@ function Send-TeamsMessageBody {
         [string] $Body
     )
     try {
-        $Execute = Invoke-RestMethod -URI $URI -Method Post -Body $Body -ContentType 'application/json'
+        $Execute = Invoke-RestMethod -Uri $uri -Method Post -Body $Body -ContentType 'application/json; charset=UTF-8'
     } catch {
         $ErrorMessage = $_.Exception.Message -replace "`n", " " -replace "`r", " "
         Write-Warning "Send-TeamsMessageBody - Failed with error message: $ErrorMessage"


### PR DESCRIPTION
Fixes #8 

I haven't been able to find a list stating which encodings are supported, so for starters I've added UTF-8 as default.

If we take a look at the documentation for [Export-Csv](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-6#parameters) other types are listed, but to be honest I'm not sure about the difference between UTF-8 or e.g. UTF-32.