### PR TITLE
Add support for custom activity image file system path

### DIFF
--- a/Public/New-TeamsActivityImage.ps1
+++ b/Public/New-TeamsActivityImage.ps1
@@ -3,9 +3,30 @@
     [alias('ActivityImageLink', 'TeamsActivityImageLink', 'New-TeamsActivityImageLink', 'ActivityImage', 'TeamsActivityImage')]
     param(
         [Parameter(ParameterSetName = 'Image')][string][ValidateSet('Add', 'Alert', 'Cancel', 'Check', 'Disable', 'Download', 'Info', 'Minus', 'Question', 'Reload', 'None')] $Image,
-        [Parameter(ParameterSetName = 'Link')][string] $Link
+        [Parameter(ParameterSetName = 'Link')][string] $Link,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [ValidateScript({
+            if (-not ($_ | Test-Path)) {
+                throw "Path is inaccessible or does not exist"
+            }
+            if (-not ($_ | Test-Path -PathType Leaf) -or ($_ -notmatch "(\.jpg|\.png)")) {
+                throw "Path is not a file or file extension is not supported"
+            }
+            return $true
+        })]
+        [System.IO.FileInfo] $Path
     )
-    if ($Image) {
+    if ($Path) {
+        $FilePath = [System.IO.Path]::GetDirectoryName($Path)
+        $FileBaseName = [System.IO.Path]::GetFileNameWithoutExtension($Path)
+        $FileExtension = [System.IO.Path]::GetExtension($Path)
+        @{
+            ActivityImageLink = Get-Image -PathToImages $FilePath -FileName $FileBaseName -FileExtension $FileExtension -Verbose
+            type              = 'ActivityImage'
+        }
+    }
+    elseif ($Image) {
         if ($Image -ne 'None') {
             $StoredImages = [IO.Path]::Combine($PSScriptRoot, '..', 'Images')
             @{

--- a/Public/New-TeamsSection.ps1
+++ b/Public/New-TeamsSection.ps1
@@ -34,7 +34,7 @@ function New-TeamsSection {
         $ActivityImageLink = Get-Image -PathToImages $FilePath -FileName $FileBaseName -FileExtension $FileExtension # -Verbose
     }
     elseif ($ActivityImage -ne 'None') {
-        $StoredImages = [IO.Path]::Combine($PSScriptRoot, 'Images')
+        $StoredImages = [IO.Path]::Combine($PSScriptRoot, '..', 'Images')
         $ActivityImageLink = Get-Image -PathToImages $StoredImages -FileName $ActivityImage -FileExtension '.jpg' # -Verbose
     }
 

--- a/Public/New-TeamsSection.ps1
+++ b/Public/New-TeamsSection.ps1
@@ -8,14 +8,33 @@ function New-TeamsSection {
         [string] $ActivitySubtitle ,
         [string] $ActivityImageLink,
         [string][ValidateSet('Alert', 'Cancel', 'Disable', 'Download', 'Minus', 'Check', 'Add', 'None')] $ActivityImage = 'None',
+
+        [ValidateScript({
+            if (-not ($_ | Test-Path)) {
+                throw "ActivityImagePath is inaccessible or does not exist"
+            }
+            if (-not ($_ | Test-Path -PathType Leaf) -or ($_ -notmatch "(\.jpg|\.png)")) {
+                throw "ActivityImagePath is not a file or file extension is not supported"
+            }
+            return $true
+        })]
+        [System.IO.FileInfo] $ActivityImagePath,
+
         [string] $ActivityText,
         [string] $Text,
         [System.Collections.IDictionary[]]$ActivityDetails,
         [System.Collections.IDictionary[]]$Buttons,
         [switch] $StartGroup
     )
-    if ($ActivityImage -ne 'None') {
-        $StoredImages = [IO.Path]::Combine($PSScriptRoot, '..', 'Images')
+
+    if ($ActivityImagePath) { # ActivityImagePath takes precedence over ActivityImage
+        $FilePath = [System.IO.Path]::GetDirectoryName($ActivityImagePath)
+        $FileBaseName = [System.IO.Path]::GetFileNameWithoutExtension($ActivityImagePath)
+        $FileExtension = [System.IO.Path]::GetExtension($ActivityImagePath)
+        $ActivityImageLink = Get-Image -PathToImages $FilePath -FileName $FileBaseName -FileExtension $FileExtension # -Verbose
+    }
+    elseif ($ActivityImage -ne 'None') {
+        $StoredImages = [IO.Path]::Combine($PSScriptRoot, 'Images')
         $ActivityImageLink = Get-Image -PathToImages $StoredImages -FileName $ActivityImage -FileExtension '.jpg' # -Verbose
     }
 


### PR DESCRIPTION
Add param `ActivityImagePath` for function `New-TeamsSection` which accepts file system paths to image files. Will be embedded in the JSON

Usage example:
```
$Section = New-TeamsSection `
    -ActivityTitle "Title" `
    -ActivitySubtitle "Subtitle" `
    -ActivityImagePath "\\VBOXSVR\share\temp2\25 microsoft teams\Images\success.png" ` # <-- Any valid file system path
    -ActivityText "Text" `
    -ActivityDetails $Fact1, $Fact2, $Fact3
```

Example outcome:
![image](https://user-images.githubusercontent.com/762122/91966012-fcd4ef00-ed19-11ea-9425-4aff248c5120.png)
