### PR TITLE
FEATURE: Adding -DisableTextMarkdown switch to Send-TeamsMessage.

### DIFF
--- a/Private/Add-TeamsBody.ps1
+++ b/Private/Add-TeamsBody.ps1
@@ -6,7 +6,8 @@
         [string] $MessageText,
         [string] $MessageSummary,
         [System.Collections.IDictionary[]] $Sections,
-        [switch] $HideOriginalBody
+        [switch] $HideOriginalBody,
+        [switch] $DisableTextMarkdown
     )
 
     $Body = [ordered] @{
@@ -33,5 +34,9 @@
     if ($MessageText -ne '') {
         $Body.text = $MessageText
     }
+    if ($DisableTextMarkdown.IsPresent) {
+        $Body = Disable-TextMarkdown -InputObject $Body
+    }
+
     return $Body | ConvertTo-Json -Depth 6
 }

--- a/Private/Disable-TextMarkdown.ps1
+++ b/Private/Disable-TextMarkdown.ps1
@@ -1,0 +1,34 @@
+function Disable-TextMarkdown() {
+    [CmdletBinding()]
+    Param(
+        $InputJson
+    )
+
+    $ReturnBody = [ordered] @{}
+    ($InputJson | ConvertFrom-Json) | Foreach-Object {
+        $Object = $_
+        $Keys = $Object | Get-Member -MemberType NoteProperty
+        $Keys | Foreach-Object {
+            $Key = $_.Name
+            if ($Key -eq 'sections') {
+                $ReturnBody.sections = @(
+                    $Object.$Key | Foreach-Object {
+                        $Section = $_
+                        $SectionKeys = ($Section | Get-Member -MemberType NoteProperty).Name
+                        Foreach ($Item in $SectionKeys) {
+                            Switch($Item -like "*text*") {
+                                $true {
+                                    $Section."$Item" = Invoke-EscapeMarkdownCharacter -InputString $Section."$Item"
+                                }
+                            }
+                        }
+                        $Section
+                    }
+                )
+            } else {
+                $ReturnBody.$Key = $Object.$Key
+            }
+        }
+    }
+    $ReturnBody | ConvertTo-Json -Depth 10
+}

--- a/Private/Disable-TextMarkdown.ps1
+++ b/Private/Disable-TextMarkdown.ps1
@@ -1,22 +1,22 @@
 function Disable-TextMarkdown() {
     [CmdletBinding()]
     Param(
-        $InputJson
+        $InputObject
     )
 
     $ReturnBody = [ordered] @{}
-    ($InputJson | ConvertFrom-Json) | Foreach-Object {
+    $InputObject | Foreach-Object {
         $Object = $_
-        $Keys = $Object | Get-Member -MemberType NoteProperty
+        $Keys = $Object.Keys
         $Keys | Foreach-Object {
-            $Key = $_.Name
+            $Key = $_
             if ($Key -eq 'sections') {
                 $ReturnBody.sections = @(
                     $Object.$Key | Foreach-Object {
                         $Section = $_
-                        $SectionKeys = ($Section | Get-Member -MemberType NoteProperty).Name
-                        Foreach ($Item in $SectionKeys) {
-                            Switch($Item -like "*text*") {
+                        $SectionKeys = $Section.Keys
+                        Foreach ($Item in $SectionKeys.Clone()) {
+                            Switch($Item.ToLower().Contains('text')) {
                                 $true {
                                     $Section."$Item" = Invoke-EscapeMarkdownCharacter -InputString $Section."$Item"
                                 }
@@ -30,5 +30,5 @@ function Disable-TextMarkdown() {
             }
         }
     }
-    $ReturnBody | ConvertTo-Json -Depth 10
+    $ReturnBody
 }

--- a/Private/Invoke-EscapeMarkdownCharacters.ps1
+++ b/Private/Invoke-EscapeMarkdownCharacters.ps1
@@ -1,0 +1,17 @@
+function Invoke-EscapeMarkdownCharacter() {
+    [CmdletBinding()]
+    Param(
+        [char[]]$MarkdownChar = @('`','*','_','{','}','[',']','(',')','#','+','-','.','!'),
+
+        [Parameter(Mandatory)]
+        [System.String] $InputString
+    )
+
+    Process {
+        $MarkdownChar | Foreach-Object {
+            $EscapeMe = $_.ToString()
+            $InputString = $InputString.ToString().Replace($EscapeMe,"\$EscapeMe")
+        }
+        $InputString
+    }
+}

--- a/Public/Send-TeamsMessage.ps1
+++ b/Public/Send-TeamsMessage.ps1
@@ -33,10 +33,8 @@ function Send-TeamsMessage {
         -ThemeColor $ThemeColor `
         -Sections $Output `
         -MessageSummary $MessageSummary `
-        -HideOriginalBody:$HideOriginalBody.IsPresent
-    if ($DisableTextMarkdown.IsPresent) {
-        $Body = Disable-TextMarkdown -InputJson $Body
-    }
+        -HideOriginalBody:$HideOriginalBody.IsPresent `
+        -DisableTextMarkdown:$DisableTextMarkdown.IsPresent
     Write-Verbose "Send-TeamsMessage - Body $Body"
     try {
         $Execute = Invoke-RestMethod -Uri $Uri -Method Post -Body $Body -ContentType 'application/json; charset=UTF-8' -ErrorAction Stop

--- a/Public/Send-TeamsMessage.ps1
+++ b/Public/Send-TeamsMessage.ps1
@@ -10,7 +10,8 @@ function Send-TeamsMessage {
         [string]$Color,
         [switch]$HideOriginalBody,
         [System.Collections.IDictionary[]]$Sections,
-        [alias('Supress')][bool] $Suppress = $true
+        [alias('Supress')][bool] $Suppress = $true,
+        [switch]$DisableTextMarkdown
     )
     if ($SectionsInput) {
         $Output = & $SectionsInput
@@ -33,6 +34,9 @@ function Send-TeamsMessage {
         -Sections $Output `
         -MessageSummary $MessageSummary `
         -HideOriginalBody:$HideOriginalBody.IsPresent
+    if ($DisableTextMarkdown.IsPresent) {
+        $Body = Disable-TextMarkdown -InputJson $Body
+    }
     Write-Verbose "Send-TeamsMessage - Body $Body"
     try {
         $Execute = Invoke-RestMethod -Uri $Uri -Method Post -Body $Body -ContentType 'application/json; charset=UTF-8' -ErrorAction Stop


### PR DESCRIPTION
Closes #30 

I've added a `-DisableTextMarkdown` switch to `Send-TeamsMessage` . My intent for this switch is to only escape markdown characters for any message section with 'text' in the title. This would escape `ActivityText` but not escape `ActivityTitle` as an example, allowing you to continue to use Markdown to format titles and subtitles, but any section labeled `text` would be disabled and any markdown-specific characters would be escaped.

Again, this is tied to the `-DisableTextMarkdown` switch, so this will only take effect if specifically called. I have not added any help documentation for this, as I have never seen help formatted other than typical comment-based help. A tour of your help method would be a **fantastic** opportunity for me to learn. 😊

With this PR the following is now possible with the below result...
```powershell
$PoolName = "App_Pool_01"
$SectionParams = @{
    ActivityTitle    = "**Application Pool Recycle**"
    ActivitySubtitle = "_@$env:USERNAME`_ - $(Get-Date)"
    ActivityText     = "Recycled Pool: $PoolName"
    SectionInput     = [scriptblock] {
        New-TeamsButton -Name 'View Logs' -Type OpenUri -Link 'https://some.link.com'
    }
    Text             = "An app pool recycle of $PoolName was initiated by $env:USERNAME"
}
Send-TeamsMessage -DisableTextMarkdown {
    New-TeamsSection @SectionParams
} -Uri $Uri -Color DarkSeaGreen -MessageSummary 'Pool Recycle'
```

![image](https://user-images.githubusercontent.com/46715299/100833369-7373ac80-342f-11eb-8c99-7a272bf72207.png)

Notice the title is still bold, and I even used the '_' underscore character on my `@$env:USERNAME` section to prove italics still work outside of sections specifically labeled `text`.
