### PR TITLE
Verify IntelligenceX reviewer rollout

### DIFF
--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -118,12 +118,12 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@eb1e0bfa2b7300a8f3409d03b024dda0f2819708
+    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@a62d966e7b2a26175f13e7fffc31be62013802f0
     with:
       runs_on: ${{ github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true' && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]' }}
       reviewer_source: release
       reviewer_release_repo: EvotecIT/IntelligenceX
-      reviewer_release_tag: reviewer-20260419151253
+      reviewer_release_tag: reviewer-20260419153850
       repo: ${{ github.event.pull_request.number && github.repository || inputs.repo }}
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       provider: ${{ inputs.provider != '' && inputs.provider || 'openai' }}

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -86,7 +86,7 @@ on:
         required: false
         default: ''
       swarm_reviewers:
-        description: 'Override reviewer swarm roles (CSV or JSON)'
+        description: 'Override reviewer swarm roles (CSV)'
         required: false
         default: ''
       swarm_max_parallel:
@@ -105,6 +105,18 @@ on:
         description: 'Override swarm metrics/artifact capture (true|false)'
         required: false
         default: ''
+      copilot_auto_install:
+        description: 'Allow auto-install of Copilot CLI'
+        required: false
+        default: 'false'
+      copilot_auto_install_method:
+        description: 'Auto-install method (Auto/Winget/Brew/Npm/Script)'
+        required: false
+        default: 'Auto'
+      copilot_auto_install_prerelease:
+        description: 'Auto-install prerelease Copilot CLI'
+        required: false
+        default: 'false'
 
 jobs:
   # INTELLIGENCEX:BEGIN
@@ -118,12 +130,12 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@a0bcd3f112d2c7ad696da846f41652d44bc1c7d7
+    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@d6fa41a56128f97fd06ba4eff97791a5d2d03f8f
     with:
       runs_on: ${{ github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true' && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]' }}
       reviewer_source: release
       reviewer_release_repo: EvotecIT/IntelligenceX
-      reviewer_release_tag: latest
+      reviewer_release_tag: reviewer-20260419115614
       repo: ${{ github.event.pull_request.number && github.repository || inputs.repo }}
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       provider: openai
@@ -155,6 +167,9 @@ jobs:
       swarm_aggregator_model: ${{ inputs.swarm_aggregator_model }}
       swarm_fail_open_on_partial: ${{ inputs.swarm_fail_open_on_partial }}
       swarm_metrics: ${{ inputs.swarm_metrics }}
+      copilot_auto_install: ${{ inputs.copilot_auto_install == 'true' }}
+      copilot_auto_install_method: ${{ inputs.copilot_auto_install_method }}
+      copilot_auto_install_prerelease: ${{ inputs.copilot_auto_install_prerelease == 'true' }}
       include_issue_comments: true
       include_review_comments: true
       include_related_prs: true

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -162,6 +162,7 @@ jobs:
       include_review_comments: true
       include_related_prs: true
       progress_updates: true
+      wait_seconds: 180
       diagnostics: ${{ inputs.provider == 'copilot' }}
       preflight: false
       preflight_timeout_seconds: 15

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -105,18 +105,6 @@ on:
         description: 'Override swarm metrics/artifact capture (true|false)'
         required: false
         default: ''
-      copilot_auto_install:
-        description: 'Allow auto-install of Copilot CLI'
-        required: false
-        default: 'false'
-      copilot_auto_install_method:
-        description: 'Auto-install method (Auto/Winget/Brew/Npm/Script)'
-        required: false
-        default: 'Auto'
-      copilot_auto_install_prerelease:
-        description: 'Auto-install prerelease Copilot CLI'
-        required: false
-        default: 'false'
 
 jobs:
   # INTELLIGENCEX:BEGIN
@@ -167,9 +155,9 @@ jobs:
       swarm_aggregator_model: ${{ inputs.swarm_aggregator_model }}
       swarm_fail_open_on_partial: ${{ inputs.swarm_fail_open_on_partial }}
       swarm_metrics: ${{ inputs.swarm_metrics }}
-      copilot_auto_install: ${{ inputs.copilot_auto_install == 'true' }}
-      copilot_auto_install_method: ${{ inputs.copilot_auto_install_method }}
-      copilot_auto_install_prerelease: ${{ inputs.copilot_auto_install_prerelease == 'true' }}
+      copilot_auto_install: true
+      copilot_auto_install_method: Auto
+      copilot_auto_install_prerelease: true
       include_issue_comments: true
       include_review_comments: true
       include_related_prs: true

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -156,7 +156,7 @@ jobs:
       swarm_fail_open_on_partial: ${{ inputs.swarm_fail_open_on_partial }}
       swarm_metrics: ${{ inputs.swarm_metrics }}
       copilot_auto_install: true
-      copilot_auto_install_method: Auto
+      copilot_auto_install_method: Script
       copilot_auto_install_prerelease: true
       include_issue_comments: true
       include_review_comments: true

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -118,12 +118,12 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@d6fa41a56128f97fd06ba4eff97791a5d2d03f8f
+    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@e0d476860a651c6a92713840313bad1a0e1e5708
     with:
       runs_on: ${{ github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true' && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]' }}
       reviewer_source: release
       reviewer_release_repo: EvotecIT/IntelligenceX
-      reviewer_release_tag: reviewer-20260419115614
+      reviewer_release_tag: reviewer-20260419164337
       repo: ${{ github.event.pull_request.number && github.repository || inputs.repo }}
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       provider: ${{ inputs.provider != '' && inputs.provider || 'openai' }}

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -162,7 +162,7 @@ jobs:
       include_review_comments: true
       include_related_prs: true
       progress_updates: true
-      diagnostics: false
+      diagnostics: ${{ inputs.provider == 'copilot' }}
       preflight: false
       preflight_timeout_seconds: 15
       cleanup_enabled: false

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -118,12 +118,12 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@e0d476860a651c6a92713840313bad1a0e1e5708
+    uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@eb1e0bfa2b7300a8f3409d03b024dda0f2819708
     with:
       runs_on: ${{ github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true' && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]' }}
       reviewer_source: release
       reviewer_release_repo: EvotecIT/IntelligenceX
-      reviewer_release_tag: reviewer-20260419164337
+      reviewer_release_tag: reviewer-20260419151253
       repo: ${{ github.event.pull_request.number && github.repository || inputs.repo }}
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       provider: ${{ inputs.provider != '' && inputs.provider || 'openai' }}

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -126,8 +126,8 @@ jobs:
       reviewer_release_tag: reviewer-20260419115614
       repo: ${{ github.event.pull_request.number && github.repository || inputs.repo }}
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
-      provider: openai
-      model: gpt-5.4
+      provider: ${{ inputs.provider != '' && inputs.provider || 'openai' }}
+      model: ${{ inputs.model != '' && inputs.model || 'gpt-5.4' }}
       openai_model: ${{ inputs.openai_model }}
       copilot_model: ${{ inputs.copilot_model }}
       copilot_launcher: ${{ inputs.copilot_launcher }}

--- a/.intelligencex/reviewer-rollout-proof.md
+++ b/.intelligencex/reviewer-rollout-proof.md
@@ -1,0 +1,10 @@
+# IntelligenceX Reviewer Rollout Proof
+
+This file is a harmless PSTeams change used to verify that the newly installed
+IntelligenceX reviewer workflow runs on normal pull requests after the workflow
+has landed on `main`.
+
+Expected signal:
+- The `IntelligenceX Review` workflow starts on the proof pull request.
+- The reviewer posts a sticky summary comment.
+- The run uses the repository-local `.intelligencex/reviewer.json` configuration.

--- a/.intelligencex/reviewer.json
+++ b/.intelligencex/reviewer.json
@@ -1,5 +1,0 @@
-{
-  "copilot": {
-    "directTimeoutSeconds": 180
-  }
-}

--- a/.intelligencex/reviewer.json
+++ b/.intelligencex/reviewer.json
@@ -1,0 +1,5 @@
+{
+  "copilot": {
+    "directTimeoutSeconds": 180
+  }
+}


### PR DESCRIPTION
## Summary
- Add a tiny proof file to trigger the newly installed IntelligenceX reviewer workflow
- Keep this PR intentionally harmless so we can validate workflow startup, secrets, check result, and sticky comment behavior

## Expected validation
- `IntelligenceX Review` should run because the workflow was merged to `main` in #64
- The reviewer should use `.intelligencex/reviewer.json`
- If auth/secrets are missing, this PR should reveal the deployment gap cleanly

## Notes
This is a rollout proof PR. It does not need to be merged after validation unless we want to keep the proof note.